### PR TITLE
fix: corrected typo in setting constant

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ settings:
 
     CBMAIL = {
         'DEFAULT_REPLY_TO': "examplereplyto@example.com",
-        'DEFAULT_SUJECT': "Example subject",
+        'DEFAULT_SUBJECT': "Example subject",
         'BASE_URL': "https://domain.com",
         'EXTRA_DATA': {},
         'WHITELIST': []

--- a/cbmail/base.py
+++ b/cbmail/base.py
@@ -80,11 +80,11 @@ class BaseMail(object):
     def get_subject(self):
         """
         Returns the subject to be used on the subject email field
-        If one is not provided it will get the DEFAULT_SUJECT setting
+        If one is not provided it will get the DEFAULT_SUBJECT setting
         """
         if self.subject:
             return self.subject
-        return settings.DEFAULT_SUJECT
+        return settings.DEFAULT_SUBJECT
 
     def get_template_name(self):
         """ Returns the template name to be used to render the email """

--- a/cbmail/conf.py
+++ b/cbmail/conf.py
@@ -9,7 +9,7 @@ APP_NAME = 'CBMAIL'
 
 DEFAULTS = {
     'DEFAULT_REPLY_TO': 'examplereplyto@example.com',
-    'DEFAULT_SUJECT': 'Example subject',
+    'DEFAULT_SUBJECT': 'Example subject',
     'BASE_URL': None,
     'EXTRA_DATA': {},
     'WHITELIST': []

--- a/runtests.py
+++ b/runtests.py
@@ -12,7 +12,7 @@ settings.configure(
     ),
     CBMAIL={
         'DEFAULT_REPLY_TO': "replyto@unittest.com",
-        'DEFAULT_SUJECT': "Unit test default",
+        'DEFAULT_SUBJECT': "Unit test default",
         'BASE_URL': "https://domain.com",
     },
     DEFAULT_FROM_EMAIL="unit@unit.com",


### PR DESCRIPTION
This corrects the subject typo from DEFAULT_SUJECT to DEFAULT_SUBJECT

Fixes dipcode-software/django-cbmail#22